### PR TITLE
enabled config.appendExtensionName for snowpack

### DIFF
--- a/src/ttsclib.ts
+++ b/src/ttsclib.ts
@@ -208,7 +208,11 @@ export function moduleSpecifierTransform(
                 const e = opt.enum
                 switch (e) {
                     case 'snowpack':
-                        return { nextPath: `${config.webModulePath ?? '/web_modules/'}${path}.js`, type: 'rewrite' }
+                        const nextPath = appendExtensionName(
+                            path,
+                            config.appendExtensionName === true ? '.js' : config.appendExtensionName ?? '.js',
+                        )
+                        return { nextPath: `${config.webModulePath ?? '/web_modules/'}${nextPath}`, type: 'rewrite' }
                     case 'pikacdn':
                     case 'unpkg': {
                         const a = 'https://cdn.pika.dev/$packageName$@$version$$subpath$'


### PR DESCRIPTION
Does not add .js extension twice if import already has it

prevents typescript code import 'file.js' to become import 'file.js.js';